### PR TITLE
feat: GoogleログインボタンにGoogleアイコンを追加

### DIFF
--- a/client/locale/auth/SignIn.json
+++ b/client/locale/auth/SignIn.json
@@ -7,6 +7,8 @@
   "toastFailed": "ログインに失敗しました",
   "toastSuccess": "ログインしました",
   "defaultError": "ログインに失敗しました。入力内容を確認してください。",
+  "googleSubmit": "Googleでログイン",
+  "googleSubmitting": "ログイン中...",
   "switchLink": "新規登録はこちら",
   "errorMessages": {
     "invalid login credentials": "メールアドレスまたはパスワードが正しくありません。",

--- a/client/src/components/auth/SignIn.tsx
+++ b/client/src/components/auth/SignIn.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 import type { FormEvent } from 'react'
-import { Alert, Box, Button, Stack, TextField } from '@mui/material'
+import { Alert, Box, Button, Divider, Stack, TextField, Typography } from '@mui/material'
+import GoogleIcon from '@mui/icons-material/Google'
 import { greenOutlinedInputSx, softGreenButtonSx } from '@/constants/styles'
 import { supabase } from '@/lib/supabase'
 import locale from '../../../locale/auth/SignIn.json'
@@ -12,12 +13,31 @@ type SignInProps = {
 function SignIn({ onMessage }: SignInProps) {
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
-  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [submitMode, setSubmitMode] = useState<'email' | 'google' | null>(null)
   const [error, setError] = useState<string | null>(null)
+
+  const handleGoogleSignIn = async () => {
+    setSubmitMode('google')
+    setError(null)
+
+    const redirectTo = new URL(import.meta.env.BASE_URL, window.location.origin).toString()
+
+    const { error: googleError } = await supabase.auth.signInWithOAuth({
+      provider: 'google',
+      options: { redirectTo },
+    })
+
+    if (googleError) {
+      setError(locale.defaultError)
+      onMessage?.(locale.toastFailed)
+    }
+
+    setSubmitMode(null)
+  }
 
   const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault()
-    setIsSubmitting(true)
+    setSubmitMode('email')
     setError(null)
 
     const { error: signInError } = await supabase.auth.signInWithPassword({
@@ -29,12 +49,12 @@ function SignIn({ onMessage }: SignInProps) {
       const normalized = signInError.message.trim().toLowerCase()
       setError(locale.errorMessages[normalized as keyof typeof locale.errorMessages] ?? locale.defaultError)
       onMessage?.(locale.toastFailed)
-      setIsSubmitting(false)
+      setSubmitMode(null)
       return
     }
 
     onMessage?.(locale.toastSuccess)
-    setIsSubmitting(false)
+    setSubmitMode(null)
   }
 
   return (
@@ -62,8 +82,30 @@ function SignIn({ onMessage }: SignInProps) {
           fullWidth
           sx={greenOutlinedInputSx}
         />
-        <Button type="submit" variant="contained" disabled={isSubmitting} sx={softGreenButtonSx}>
-          {isSubmitting ? locale.submitting : locale.submit}
+        <Button type="submit" variant="contained" disabled={submitMode !== null} sx={softGreenButtonSx}>
+          {submitMode === 'email' ? locale.submitting : locale.submit}
+        </Button>
+        <Divider>
+          <Typography variant="caption" color="text.secondary">
+            または
+          </Typography>
+        </Divider>
+        <Button
+          type="button"
+          variant="outlined"
+          disabled={submitMode !== null}
+          startIcon={<GoogleIcon />}
+          onClick={handleGoogleSignIn}
+          sx={{
+            borderColor: '#dadce0',
+            color: '#3c4043',
+            backgroundColor: '#ffffff',
+            textTransform: 'none',
+            fontWeight: 500,
+            '&:hover': { backgroundColor: '#f8f9fa', borderColor: '#dadce0' },
+          }}
+        >
+          {submitMode === 'google' ? locale.googleSubmitting : locale.googleSubmit}
         </Button>
         {error ? <Alert severity="error">{error}</Alert> : null}
       </Stack>


### PR DESCRIPTION
SignInコンポーネントにGoogle OAuthログインボタン（@mui/icons-material/Google使用）を追加。 メール/パスワードフォームの下にディバイダーと「Googleでログイン」ボタンを配置。